### PR TITLE
Add timeout for opening connection to DTU

### DIFF
--- a/hoymiles_wifi/dtu.py
+++ b/hoymiles_wifi/dtu.py
@@ -370,8 +370,13 @@ class DTU:
 
         async with self.mutex:
             try:
-                reader, writer = await asyncio.open_connection(
-                    host=self.host, port=dtu_port, local_addr=ip_to_bind
+                reader, writer = await asyncio.wait_for(
+                    asyncio.open_connection(
+                        host=self.host,
+                        port=dtu_port,
+                        local_addr=ip_to_bind,
+                    ),
+                    timeout=5,
                 )
 
                 writer.write(message)


### PR DESCRIPTION
I'm using the library through the Home Assistant integration. Whenever I restart HA while the inverter is offline (e.g. in the evening -> no sun), HA takes ages to restart because it is waiting for the Hoymiles Wifi integration to finish. Ultimately it fails with a global task timeout with the following traceback:

```
2024-10-09 21:48:22.342 ERROR (MainThread) [homeassistant.config_entries] Error setting up entry 10.x.x.x for hoymiles_wifi
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/homeassistant/config_entries.py", line 594, in async_setup
    result = await component.async_setup_entry(hass, self)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/hoymiles_wifi/__init__.py", line 84, in async_setup_entry
    await app_info_update_coordinator.async_config_entry_first_refresh()
  File "/usr/local/lib/python3.12/site-packages/homeassistant/helpers/update_coordinator.py", line 281, in async_config_entry_first_refresh
    await self._async_refresh(
  File "/usr/local/lib/python3.12/site-packages/homeassistant/helpers/update_coordinator.py", line 354, in _async_refresh
    self.data = await self._async_update_data()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/hoymiles_wifi/coordinator.py", line 97, in _async_update_data
    response = await self._dtu.async_app_information_data()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/.local/lib/python3.12/site-packages/hoymiles_wifi/dtu.py", line 158, in async_app_information_data
    return await self.async_send_request(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/.local/lib/python3.12/site-packages/hoymiles_wifi/dtu.py", line 370, in async_send_request
    async with self.mutex:
  File "/usr/local/lib/python3.12/asyncio/locks.py", line 14, in __aenter__
    await self.acquire()
  File "/usr/local/lib/python3.12/asyncio/locks.py", line 113, in acquire
    await fut
asyncio.exceptions.CancelledError: Global task timeout
```

My understanding is, that the setup routine is trying to open a connection to the DTU but hangs because it's offline. Therefore, it's holding the mutex. Some other part of Home Assistant then tries to update the device and hangs on taking the mutex. I think this would be easily fixed by adding a timeout to opening the connection to the DTU, which is what this PR proposes.