### PR TITLE
fix: absolute_start when response is paginated

### DIFF
--- a/hoymiles_wifi/dtu.py
+++ b/hoymiles_wifi/dtu.py
@@ -234,6 +234,9 @@ class DTU:
         )
 
         if response is not None:
+            # Save initial absolute_start and other relevant props
+            initial_absolute_start = response.absolute_start
+
             combined_response.MergeFrom(response)
 
             # Fetch additional data based on the value of response.ap
@@ -247,6 +250,9 @@ class DTU:
                 )
                 if additional_response is not None:
                     combined_response.MergeFrom(additional_response)
+
+            # Restore the initial values after merging
+            combined_response.absolute_start = initial_absolute_start
 
         return combined_response if combined_response.ByteSize() > 0 else None
 


### PR DESCRIPTION
Hi there,

i found an issue, when the history func is called and response gets paginated. the `absolute_start` won't match anymore. Here my sample (shortend)

the length of array was > 800 for the whole day and got paginated. check the request time and the absolute_start time. this seems weird, because i'm querying the whole day.

```
ap: 4
cp: 3
offset: 7200
request_time: 1758388156 (Sat Sep 20 2025 19:09:16 GMT+0200)
start_time: 1
long_term_start: 36030288
absolute_start: 1758379637 (Sat Sep 20 2025 16:47:17 GMT+0200)
step_time: 60
total_energy: asdf
daily_energy: 2509
power_array: 0
.... shortend
power_array: 26
power_array: 24
power_array: 22
power_array: 20
power_array: 0
power_array: 0
power_array: 0
power_array: 0
power_array: 0
power_array: 0
power_array: 0
power_array: 0
```

For me a workaround works, but fixing would be appreciated.
```
        timestamp = history_response.request_time - (len(history_response.power_array) * step_time) + (i * step_time)
```

