### PR TITLE
Add power mapping for HMS-1000-2T (0x1410)

### DIFF
--- a/hoymiles_wifi/hoymiles.py
+++ b/hoymiles_wifi/hoymiles.py
@@ -65,6 +65,7 @@ power_mapping = {
     0x1161: InverterPower.P_1000_1200_1500,
     0x1164: InverterPower.P_1600_1800_2000,
     0x1400: InverterPower.P_450,
+    0x1410: InverterPower.P_1000,
     0x1412: InverterPower.P_800W_1000W,
     0x1382: InverterPower.P_2250,
     0x2821: InverterPower.P_1000,


### PR DESCRIPTION
Recognise inverter serial prefix 0x14 0x10 as 1000W so get_inverter_power and get_inverter_model_name return HMS-1000-2T instead of raising Unknown power.

Made-with: Cursor