### PR TITLE
docs(installation): add isolated venv install instructions (Linux/macOS/Windows)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,53 @@ The library was successfully tested with:
 
 ## Installation
 
+### Quick install (system-wide or existing environment)
+
+```bash
+pip install hoymiles-wifi
 ```
-$ pip install hoymiles-wifi
+
+### Isolated install with a virtual environment (recommended)
+
+A virtual environment keeps the library and its dependencies isolated from your
+system Python and other projects. Works on Linux, macOS, and Windows.
+
+**Linux / macOS**
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install hoymiles-wifi
+```
+
+**Windows (PowerShell)**
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+pip install hoymiles-wifi
+```
+
+**Windows (Command Prompt)**
+
+```cmd
+python -m venv .venv
+.\.venv\Scripts\activate.bat
+python -m pip install --upgrade pip
+pip install hoymiles-wifi
+```
+
+After activation, the `hoymiles-wifi` command is available inside the venv.
+To leave the environment, run `deactivate`.
+
+**Editable install from a cloned source tree** (for development):
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate        # Windows: .\.venv\Scripts\Activate.ps1
+pip install -e .
 ```
 
 ## Usage


### PR DESCRIPTION
# Feature: Isolated virtualenv installation instructions

## Summary

The README only documented a bare `pip install hoymiles-wifi`. This adds a
recommended, isolated install path using a Python virtual environment, with
explicit commands for Linux/macOS and both Windows shells (PowerShell and
cmd), plus an editable install for development. The existing quick-install
line is kept as a "system-wide / existing environment" option.

## Why

A venv keeps `protobuf`, `crcmod`, and `cryptography` isolated from the system
Python and from other projects, avoiding version conflicts and the need for
`--break-system-packages` on modern Python. Many users (especially on the
Hermes/Home Assistant side) run this in a dedicated environment.

## How it was done (reproducible steps)

1. Cloned the repo and forked it to a personal fork.
2. Created a feature branch: `feature/venv-installation`.
3. Verified the venv flow actually works on Windows (Python 3.11):
   ```
   python -m venv .venv
   .\.venv\Scripts\Activate.ps1
   python -m pip install --upgrade pip
   pip install -e .
   hoymiles-wifi --help      # -> CLI help printed, install confirmed
   ```
4. Extended the `## Installation` section in `README.md` with:
   - Quick install (unchanged `pip install`)
   - Isolated venv install (Linux/macOS, Windows PowerShell, Windows cmd)
   - Editable install from a cloned source tree
5. Confirmed `.venv` is already covered by `.gitignore` (no venv artifacts committed).
6. Committed with a Conventional Commits message and opened this PR.

## How to test

```bash
python3 -m venv .venv
source .venv/bin/activate        # Windows: .\.venv\Scripts\Activate.ps1
pip install --upgrade pip
pip install hoymiles-wifi
hoymiles-wifi --host <IP> get-real-data-new --as-json
```

## Platforms tested

- Windows 11 (Python 3.11.15) — venv + `pip install -e .` verified, CLI runs.
- Linux/macOS commands are the standard `python3 -m venv` flow and match the
  already-published pyproject (requires-python >=3.9).

## Related

- Source branch: `feature/venv-installation`
- No behavioral change; documentation only.
